### PR TITLE
CYTHINF-89 Fix Template Filename

### DIFF
--- a/cicd.template.yml
+++ b/cicd.template.yml
@@ -170,7 +170,7 @@ Resources:
                   "MessageBody": {
                     "StackName": "${GithubRepo}",
                     "ZipLocation.$": "$.BuildOutput.Build.Artifacts.Location",
-                    "TemplateFileName": "${GithubRepo}.template.yml",
+                    "TemplateFileName": "SamlProvider.template.yml",
                     "RoleArn": "${SharedRoleArn}",
                     "Token.$": "$$.Task.Token",
                     "Capabilities": [


### PR DESCRIPTION
Fixes the template filename in the step functions pipeline (should be SamlProvider.template.yml)