### PR TITLE
CYTHINF-89 Fix Capability typo

### DIFF
--- a/cicd.template.yml
+++ b/cicd.template.yml
@@ -199,7 +199,7 @@ Resources:
                       "SamlProviderLambdaArn.$": "$.SharedOutputs.SamlProviderLambdaArn"
                     },
                     "Capabilities": [
-                      "CAPABILIT_IAM"
+                      "CAPABILITY_IAM"
                     ]
                   }
                 },


### PR DESCRIPTION
This fixes the typo in CAPABILITY_IAM on the step functions pipeline. 